### PR TITLE
chore(deps): switch to @apollo/subgraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "src/*"
   ],
   "dependencies": {
-    "@apollo/federation": "^0.26.0",
+    "@apollo/subgraph": "^0.1.5",
     "@graphql-tools/utils": "^7.9.1",
     "get-stdin": "^9.0.0",
     "graphql": "^15.5.0",

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,5 +1,5 @@
 import { buildSchema, GraphQLObjectType, GraphQLSchema, parse } from "graphql";
-import federation from "@apollo/federation";
+import subgraph from "@apollo/subgraph";
 import { printSchemaWithDirectives } from "@graphql-tools/utils";
 
 /**
@@ -9,26 +9,7 @@ import { printSchemaWithDirectives } from "@graphql-tools/utils";
  */
 export function fromFederatedSDLToValidSDL(sdl) {
   const parsed = parse(sdl);
-  const schema = federation.buildFederatedSchema(parsed);
-
-  // schema applied directives are lost, but we can add them back
-  const originalSchemaDirectives =
-    parsed.definitions.find(
-      /** @type {(def: any) => def is import("graphql").SchemaDefinitionNode} */
-      (def) => def.kind === "SchemaDefinition"
-    )?.directives ?? [];
-
-  schema.astNode = {
-    // satisfies the type checker
-    kind: "SchemaDefinition",
-    operationTypes: [],
-
-    ...(schema.astNode ?? {}),
-    directives: [
-      ...(schema.astNode?.directives ?? []),
-      ...originalSchemaDirectives,
-    ],
-  };
+  const schema = subgraph.buildSubgraphSchema(parsed);
 
   return printSchemaWithDirectives(schema);
 }
@@ -60,5 +41,5 @@ export function fromValidSDLToFederatedSDL(sdl) {
     types: typesWithoutQuery,
   });
 
-  return federation.printSchema(schemaWithoutFederationRootFields);
+  return subgraph.printSubgraphSchema(schemaWithoutFederationRootFields);
 }

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -6,7 +6,9 @@ import {
 test("fromFederatedSDLToValidSDL", async () => {
   expect(
     fromFederatedSDLToValidSDL(`
-    schema @core(feature: "http://specs.apollo.dev/core/v0.1") {
+    directive @myDirective on SCHEMA
+
+    schema @myDirective {
       query: Query
     }
 
@@ -19,12 +21,12 @@ test("fromFederatedSDLToValidSDL", async () => {
       username: String! @custom
     }
 
-    directive @core(feature: String!) repeatable on SCHEMA 
+    directive @core(feature: String!) repeatable on SCHEMA
 
     directive @custom on FIELD_DEFINITION
   `)
   ).toMatchInlineSnapshot(`
-    "schema @core(feature: \\"http://specs.apollo.dev/core/v0.1\\") {
+    "schema @myDirective {
       query: Query
     }
 
@@ -38,9 +40,7 @@ test("fromFederatedSDLToValidSDL", async () => {
 
     directive @provides(fields: String!) on FIELD_DEFINITION
 
-    directive @inaccessible on FIELD_DEFINITION
-
-    directive @tag(name: String!) repeatable on FIELD_DEFINITION
+    directive @myDirective on SCHEMA
 
     directive @core(feature: String!) repeatable on SCHEMA
 
@@ -111,13 +111,13 @@ test("fromValidSDLToFederatedSDL", async () => {
   ).toMatchInlineSnapshot(`
     "directive @custom on FIELD_DEFINITION
 
-    type Query {
-      me: User
-    }
-
     type User @key(fields: \\"id\\") {
       id: ID!
       username: String!
+    }
+
+    type Query {
+      me: User
     }
     "
   `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,12 @@
 # yarn lockfile v1
 
 
-"@apollo/federation@^0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@apollo/federation/-/federation-0.26.0.tgz#72c89f01995bd2e066d447fed4aa58678d759bf6"
-  integrity sha512-j3l6lhQod630LQzLm2hhDyQQJtQikT7vRtRgIa3PuKEq6ouuOd1OQERhBnecobJlUfRWJkfvjYJ/PhQZ2sm/7Q==
+"@apollo/subgraph@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@apollo/subgraph/-/subgraph-0.1.5.tgz#ae5a1c686c97b7a2c3f7575d570f5c004578e2fd"
+  integrity sha512-i1uU9llldGMV7GcBOUQRqnbGfgOpc6nrOVw93oKlugZq5R00q8y/RX8KgvMfdXZyr4MJ2/gO6Kw7LzbjCKU+Kw==
   dependencies:
-    apollo-graphql "^0.9.3"
-    lodash.xorby "^4.7.0"
+    apollo-graphql "^0.9.5"
 
 "@ardatan/aggregate-error@0.0.6":
   version "0.0.6"
@@ -924,10 +923,10 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo-graphql@^0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/apollo-graphql/-/apollo-graphql-0.9.3.tgz#1ca6f625322ae10a66f57a39642849a07a7a5dc9"
-  integrity sha512-rcAl2E841Iko4kSzj4Pt3PRBitmyq1MvoEmpl04TQSpGnoVgl1E/ZXuLBYxMTSnEAm7umn2IsoY+c6Ll9U/10A==
+apollo-graphql@^0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/apollo-graphql/-/apollo-graphql-0.9.5.tgz#9113483ca7f7fa49ee9e9a299c45d30b1cf3bf61"
+  integrity sha512-RGt5k2JeBqrmnwRM0VOgWFiGKlGJMfmiif/4JvdaEqhMJ+xqe/9cfDYzXfn33ke2eWixsAbjEbRfy8XbaN9nTw==
   dependencies:
     core-js-pure "^3.10.2"
     lodash.sortby "^4.7.0"
@@ -2349,11 +2348,6 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
-
-lodash.xorby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.xorby/-/lodash.xorby-4.7.0.tgz#9c19a6f9f063a6eb53dd03c1b6871799801463d7"
-  integrity sha1-nBmm+fBjputT3QPBtocXmYAUY9c=
 
 lodash@^4.7.0:
   version "4.17.21"


### PR DESCRIPTION
This removes the need to preserve schema directives, so this package is far less necessary than it used to be.